### PR TITLE
migrate server to Streamable HTTP transport

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,24 +1,21 @@
 {
   "name": "@supadata/mcp",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@supadata/mcp",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.15.1",
+        "@modelcontextprotocol/sdk": "^1.17.3",
         "@supadata/js": "^1.3.0",
         "dotenv": "^16.4.7",
         "express": "^5.1.0",
         "shx": "^0.3.4",
         "ws": "^8.18.1",
         "zod": "^3.25.76"
-      },
-      "bin": {
-        "supadata-mcp": "dist/index.js"
       },
       "devDependencies": {
         "@jest/globals": "^29.7.0",

--- a/package.json
+++ b/package.json
@@ -3,20 +3,17 @@
   "version": "1.0.1",
   "description": "MCP server for Supadata video & web scraping integration. Features include YouTube, TikTok, Instagram, Twitter, and file video transcription, web scraping, batch processing and structured data extraction.",
   "type": "module",
-  "module": "./src/index.ts",
-  "bin": {
-    "supadata-mcp": "dist/index.js"
-  },
-  "files": [
-    "dist"
-  ],
-  "publishConfig": {
-    "access": "public"
-  },
+  "module": "src/index.ts",
   "scripts": {
-    "build": "tsc && node -e \"require('fs').chmodSync('dist/index.js', '755')\"",
+    "dev": "npx @smithery/cli dev",
+    "build": "npm run build:http",
+    "build:stdio": "tsc",
+    "build:http": "npx @smithery/cli build",
+    "start": "npm run start:http",
+    "start:http": "node .smithery/index.cjs",
+    "start:stdio": "RUN_STDIO=true node dist/index.js",
+    "prepublishOnly": "npm run build:stdio",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
-    "start": "node dist/index.js",
     "lint": "eslint src/**/*.ts",
     "lint:fix": "eslint src/**/*.ts --fix",
     "format": "prettier --write .",
@@ -25,7 +22,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.15.1",
+    "@modelcontextprotocol/sdk": "^1.17.3",
     "@supadata/js": "^1.3.0",
     "dotenv": "^16.4.7",
     "express": "^5.1.0",

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,17 +1,1 @@
-# Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
-
-startCommand:
-  type: stdio
-  configSchema:
-    # JSON Schema defining the configuration options for the MCP.
-    type: object
-    required:
-      - supadataApiKey
-    properties:
-      supadataApiKey:
-        type: string
-        description: Your Supadata API key.
-  commandFunction:
-    # A function that produces the CLI command to start the MCP on stdio.
-    |-
-    (config) => ({ command: 'node', args: ['dist/index.js'], env: { SUPADATA_API_KEY: config.supadataApiKey } })
+runtime: 'typescript'


### PR DESCRIPTION
/claim #2

This commit migrates the MCP server from the deprecated STDIO transport to the new Streamable HTTP transport, as required by the Smithery platform.

The main changes include:
 - Updating `smithery.yaml` to use the `typescript` runtime.
 - Refactoring `src/index.ts` to export a `createServer` function for the Smithery CLI, while maintaining backward compatibility with STDIO for local development.
 - Updating `package.json` with the new dependencies and scripts for building and running the server in both HTTP and STDIO modes.