### PR TITLE
Fix MCP server authentication and logging issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@supadata/mcp",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "MCP server for Supadata video & web scraping integration. Features include YouTube, TikTok, Instagram, Twitter, and file video transcription, web scraping, batch processing and structured data extraction.",
   "type": "module",
   "bin": "./dist/index.js",

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -6,7 +6,7 @@ import {
 import { z } from 'zod';
 
 async function callSupadata(path: string, args: any, apiKey: string, method: 'GET' | 'POST' = 'GET') {
-  console.error(`[MCP] Calling Supadata: ${method} ${path}, Key length: ${apiKey?.length ?? 0}`);
+  console.log(`[MCP] Calling Supadata: ${method} ${path}, Key length: ${apiKey?.length ?? 0}`);
 
   let url = `https://api.supadata.ai/v1${path}`;
   const headers: Record<string, string> = {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -6,6 +6,35 @@ import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
 
 export default {
   async fetch(request: Request, env: { SUPADATA_API_KEY: string }, _ctx: any): Promise<Response> {
+    // Health check — no server/transport needed
+    const url = new URL(request.url);
+    if (url.pathname === '/' && request.method === 'GET') {
+      return new Response('Supadata MCP Worker is running.', {
+        status: 200,
+        headers: { 'Content-Type': 'text/plain' },
+      });
+    }
+
+    // In stateless mode, only POST is supported for JSON-RPC requests.
+    // GET (SSE streams) and DELETE (session termination) don't work
+    // because server.close() in the finally block would terminate them.
+    if (request.method !== 'POST') {
+      return new Response(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          error: {
+            code: -32000,
+            message: 'Method not allowed. Use POST for JSON-RPC requests.',
+          },
+          id: null,
+        }),
+        {
+          status: 405,
+          headers: { 'Content-Type': 'application/json', Allow: 'POST' },
+        },
+      );
+    }
+
     let server: Server | null = null;
 
     try {
@@ -24,13 +53,14 @@ export default {
       }
 
       if (!apiKey) {
-        console.error('CRITICAL: No API key provided via headers (x-api-key) or environment (SUPADATA_API_KEY).');
+        console.warn('No API key provided via headers (x-api-key) or environment (SUPADATA_API_KEY).');
       } else {
         console.log(`Received API Key (length: ${apiKey.length})`);
       }
 
       const transport = new WebStandardStreamableHTTPServerTransport({
         sessionIdGenerator: undefined,
+        enableJsonResponse: true,
       });
 
       const result = createMcpServer({
@@ -40,35 +70,17 @@ export default {
 
       await server.connect(transport);
 
-      if (apiKey) {
-        const prefix = apiKey.substring(0, 4);
-        const suffix = apiKey.substring(apiKey.length - 4);
-        console.error(`Received API Key (length: ${apiKey.length}). Debug: ${prefix}...${suffix}`);
-      } else {
-        console.error('CRITICAL: API Key is empty!');
-      }
-
-      const url = new URL(request.url);
-      if (url.pathname === '/' && request.method === 'GET') {
-        return new Response('Supadata MCP Worker is running. Endpoint: /message or /sse', {
-          status: 200,
-          headers: { 'Content-Type': 'text/plain' }
-        });
-      }
-
       const response = await transport.handleRequest(request);
       return response ?? new Response('Not Found', { status: 404 });
 
     } catch (err: any) {
       console.error('Worker Error:', err);
-      const actualEnvKey = env.SUPADATA_API_KEY ? 'Present' : 'Missing';
-      const debugMsg = `Server Internal Error: ${err?.message}. Env Status: ${actualEnvKey}`;
 
       return new Response(
         JSON.stringify({
-          error: debugMsg,
+          error: `Server Internal Error: ${err?.message}`,
         }),
-        { status: 500 }
+        { status: 500, headers: { 'Content-Type': 'application/json' } },
       );
     } finally {
       if (server) {


### PR DESCRIPTION
## Summary

Fixed two critical issues with the Cloudflare Worker MCP server preventing proper authentication and exposing sensitive data in logs.

**Issue 1 – Claude Code shows "Authenticate" button**: The transport was using SSE streaming responses, but `server.close()` in the finally block terminated the stream before data was delivered. Now uses JSON response mode where responses are fully formed before cleanup.

**Issue 2 – API key leaked in error logs**: Debug logging exposed the first/last 4 characters of the API key (`sd_a...f7c5`) and was logged at error level in Cloudflare. Now only logs key length at log level, and removed environment status leaks from error responses.

## Changes

- `src/worker.ts`: Enable `enableJsonResponse: true`, handle GET/DELETE before transport creation (return 405), remove API key logging, change console.error to console.warn for missing keys, clean up error responses
- `src/mcp.ts`: Change informational trace from console.error to console.log (line 9)
- `package.json`: Bump version to 1.2.2

## Testing

Verified locally with curl against wrangler dev:
- `initialize` → proper JSON-RPC response with capabilities
- `tools/list` → all 9 tools returned  
- `tools/call` → reaches Supadata API successfully
- `GET /` → health check 200
- `GET /mcp` → 405 (method not allowed, not confusing errors)
- All 14 existing Jest tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)