### PR TITLE
docs: add Glama MCP badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Supadata MCP Server
 
+[![supadata-ai/mcp MCP server](https://glama.ai/mcp/servers/@supadata-ai/mcp/badges/score.svg)](https://glama.ai/mcp/servers/@supadata-ai/mcp)
+
 A Model Context Protocol (MCP) server that integrates with [Supadata](https://supadata.ai) for video transcript extraction, web scraping, crawling, and site discovery.
 
 ## Features


### PR DESCRIPTION
Adds the Glama score badge to the top of the README, just under the title.

This satisfies the new listing requirement for our [awesome-mcp-servers PR #7701](https://github.com/punkpeye/awesome-mcp-servers/pull/7701), where the Glama bot now requires a Glama score badge alongside the listing. The server is already published on Glama at https://glama.ai/mcp/servers/@supadata-ai/mcp and passes its checks.

Badge added:

```md
[![supadata-ai/mcp MCP server](https://glama.ai/mcp/servers/@supadata-ai/mcp/badges/score.svg)](https://glama.ai/mcp/servers/@supadata-ai/mcp)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)